### PR TITLE
fix(utils): support custom shop name

### DIFF
--- a/util.go
+++ b/util.go
@@ -14,6 +14,9 @@ func ShopFullName(name string) string {
 	if strings.Contains(name, "myshopify.com") {
 		return name
 	}
+	if strings.Contains(name, ".") {
+		return name
+	}
 	return name + ".myshopify.com"
 }
 

--- a/util_test.go
+++ b/util_test.go
@@ -16,6 +16,7 @@ func TestShopFullName(t *testing.T) {
 		{"myshop ", "myshop.myshopify.com"},
 		{"myshop \n", "myshop.myshopify.com"},
 		{"myshop.myshopify.com", "myshop.myshopify.com"},
+		{"my-custom-shop.com", "my-custom-shop.com"},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
When the shop has its own customized domain, the custom domain should not be changed in the `ShopFullName` function.